### PR TITLE
Standardize responses and classes

### DIFF
--- a/src/ServiceHotelsList.php
+++ b/src/ServiceHotelsList.php
@@ -4,21 +4,24 @@ namespace StayForLong\HotelBeds;
 
 final class ServiceHotelsList
 {
-	private $response;
+	private $request;
 
 	/**
 	 * @param ServiceRequest $request
 	 */
 	public function __construct(ServiceRequest $request)
 	{
-		$this->response = $request->setOptions("hotels")->send();
+		$this->request = $request->setOptions("hotels");
 	}
 
 	public function __invoke()
 	{
 		try {
-			$response = $this->response->getBody();
-			return json_decode( $response, true);
+			$response = $this->request
+				->send()
+				->getBody();
+
+			return json_decode($response, true);
 		} catch (ServiceRequestException $e) {
 			throw new ServiceHotelsListException($e->getMessage());
 		}

--- a/src/ServiceLocationList.php
+++ b/src/ServiceLocationList.php
@@ -16,7 +16,6 @@ final class ServiceLocationList
 			$this->request = $request
 				->setOptions("locations")
 				->setOptions($location_type);
-
 		} catch (ServiceRequestException $e) {
 			throw new ServiceLocationListException($e->getMessage());
 		}
@@ -25,9 +24,11 @@ final class ServiceLocationList
 	public function __invoke()
 	{
 		try {
-			$response['body'] = json_decode($this->request->send()->getBody(), true);
+			$response = $this->request
+				->send()
+				->getBody();
 
-			return $response;
+			return json_decode(response, true);
 		} catch (ServiceRequestException $e) {
 			throw new ServiceLocationListException($e->getMessage());
 		}


### PR DESCRIPTION
I noticed classes were returning different payloads.
Don't think there is a need to have Types payload inside 'body', being the only one and different from the rest.